### PR TITLE
[!!] Heading: What to Expect  -> Can and Can't Do

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,8 +22,8 @@ order: 1
 
 Web accessibility evaluation tools are software programs or online services that help determine if a website is accessible. This document highlights features of evaluation tools, and discusses different aspects to consider when selecting these tools. Links to different tools are provided in the [Web Accessibility Evaluation Tools List](https://www.w3.org/WAI/ER/tools/).
 
-## What to Expect from Evaluation Tools
-{:#Expect}
+## What Evaluation Tools Can Do and Can *Not* Do
+{:#cannot}
 
 Web accessibility evaluation tools can help you quickly identify potential accessibility issues. You can use them through all phases of the web design and development process. Tools can provide fully-automated checks, and help you with manual review.
 


### PR DESCRIPTION
Some of the target audience for this resource think that Eval Tools can automatically catch most, if not all, accessibility issues. I think it is important that we very clearly communicate that that is not the case &mdash; including with the heading.

(Previous version had "[What evaluation tools can do](https://www.w3.org/WAI/eval/selectingtools#benefits)" and "[What evaluation tools can not do](https://www.w3.org/WAI/eval/selectingtools#caution)". )